### PR TITLE
fixed a typo in incoming/routing.html

### DIFF
--- a/docs/incoming/routing.html
+++ b/docs/incoming/routing.html
@@ -475,7 +475,7 @@ and the “productLookup” method:</p>
 </div>
 <p>A URL with “product” as the first segment, and a number in the second will be remapped to the “Catalog” class
 and the “productLookupByID” method passing in the match as a variable to the method:</p>
-<div class="highlight-html+php notranslate"><div class="highlight"><pre><span></span><span class="nv">$routes</span><span class="o">-&gt;</span><span class="na">add</span><span class="p">(</span><span class="s1">&#39;product/(:num)&#39;</span><span class="p">,</span> <span class="s1">&#39;Catalog::productLookupByID/$1&#39;</span><span class="p">;</span>
+<div class="highlight-html+php notranslate"><div class="highlight"><pre><span></span><span class="nv">$routes</span><span class="o">-&gt;</span><span class="na">add</span><span class="p">(</span><span class="s1">&#39;product/(:num)&#39;</span><span class="p">,</span> <span class="s1">&#39;Catalog::productLookupByID/$1&#39;</span><span class="p">);</span>
 </pre></div>
 </div>
 <div class="admonition important">


### PR DESCRIPTION
I added the missing closing parenthesis ")" at line 478 of incoming/routing.html 

Previously: 
$routes->add('product/(:num)', 'Catalog::productLookupByID/$1';
Now: 
$routes->add('product/(:num)', 'Catalog::productLookupByID/$1');

My very first contribution on github 😄 