### PR TITLE
Typo: Products to Helloworld

### DIFF
--- a/docs/incoming/controllers.html
+++ b/docs/incoming/controllers.html
@@ -536,7 +536,7 @@ That will prevent it from being served by a URL request.</p>
 
 <span class="k">namespace</span> <span class="nx">App\Controllers</span><span class="p">;</span>
 
-<span class="k">class</span> <span class="nc">Products</span> <span class="k">extends</span> <span class="nx">BaseController</span>
+<span class="k">class</span> <span class="nc">Helloworld</span> <span class="k">extends</span> <span class="nx">BaseController</span>
 <span class="p">{</span>
     <span class="k">protected</span> <span class="k">function</span> <span class="nf">utility</span><span class="p">()</span>
     <span class="p">{</span>


### PR DESCRIPTION
Typo: Controller name Products changed to Helloworld as in code explanation.