### PR TITLE
Use validateData() to validate POST data only

### DIFF
--- a/docs/incoming/controllers.html
+++ b/docs/incoming/controllers.html
@@ -476,6 +476,7 @@ and it validates data from
 or <a class="reference internal" href="incomingrequest.html#incomingrequest-retrieving-raw-data"><span class="std std-ref">$request-&gt;getRawInput()</span></a>
 or <a class="reference internal" href="incomingrequest.html#incomingrequest-getting-data"><span class="std std-ref">$request-&gt;getVar()</span></a>, and an attacker
 could change what data is validated.</p>
+<p>If you want to use the request with only HTML post, you can use <span class="std std-ref">$validation->validateData($request->getPost(), $rules)</span>. Because <span class="std std-ref">withRequest()</span> uses <span class="std std-ref">$request->getVar()</span>, the data comes from $_GET, $_POST, $_COOKIE. This can cause a conflict if there is a same named cookie and get or post value.</p>
 </div>
 <div class="admonition note">
 <p class="admonition-title">Note</p>


### PR DESCRIPTION
Instead of withRequest(), use validateData() to validate POST data only. withRequest() uses $request->getVar() which returns $_GET, $_POST and $_COOKIE data in that order. Newer values override older values. Post values will be overriden by the cookies if they have the same name.

<!--

Each pull request should address a single issue and have a meaningful title.

- Pull requests must be in English.
- If a pull request fixes an issue, reference the issue with a suitable keyword (e.g., Fixes #123).

-->
**Description**
Explain what you have changed, and why.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
